### PR TITLE
[Create] Bổ sung bộ tài liệu và giấy phép mã nguồn mở

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Report a reproducible problem in ChatCMD
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+<!-- Describe the problem clearly. Do not include secrets or private data. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What happened instead? Include the exact sanitized error when useful. -->
+
+## Environment
+
+- ChatCMD version or commit:
+- Operating system and architecture:
+- Browser and extension version, if relevant:
+- Rust and Node.js versions, if building from source:
+- Loopback, reverse proxy, or tunnel setup:
+
+## Logs or screenshots
+
+<!-- Redact MCP tokens, cookies, personal paths, conversations, and proprietary data. -->
+
+## Additional context
+
+<!-- Include attempted fixes, regression range, or a minimal reproduction repository. -->
+
+## Checklist
+
+- [ ] I searched existing issues.
+- [ ] I reproduced this with a supported version when possible.
+- [ ] I removed all secrets and private data.
+- [ ] This is not a security vulnerability. Security reports follow `SECURITY.md`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/int04/ChatCmdClient/security/advisories/new
+    about: Report vulnerabilities privately. Do not open a public issue.
+  - name: ChatCMD documentation
+    url: https://chatcmd.net/docs
+    about: Read versioned usage guides and walkthroughs.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,29 @@
+---
+name: Documentation
+about: Report missing, unclear, or incorrect documentation
+title: "[Docs] "
+labels: documentation
+assignees: ""
+---
+
+## Location
+
+<!-- Link the page/file and heading, if known. -->
+
+## Problem
+
+<!-- What is missing, unclear, incorrect, or out of date? -->
+
+## Suggested improvement
+
+<!-- Proposed wording, example, or structure. -->
+
+## Version context
+
+- ChatCMD version or commit:
+- Operating system/browser, if relevant:
+
+## Checklist
+
+- [ ] I checked the source-controlled docs and the website docs when applicable.
+- [ ] I removed all secrets and private data.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Propose a focused improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+<!-- Describe the user problem, not only the preferred implementation. -->
+
+## Proposed outcome
+
+<!-- What should a user be able to do? -->
+
+## Suggested approach
+
+<!-- Optional implementation or UI ideas. -->
+
+## Alternatives considered
+
+<!-- Existing workflows, workarounds, or different designs. -->
+
+## Security, privacy, and compatibility
+
+<!-- Consider permissions, tokens, local files, public exposure, persistence, migrations, MCP contracts, and extension behavior. -->
+
+## Additional context
+
+<!-- Mockups, examples, related issues, or links. Remove private data. -->
+
+## Checklist
+
+- [ ] I searched existing issues and the roadmap.
+- [ ] This proposal keeps the local-first and least-privilege model in mind.
+- [ ] I am willing to help implement or test this change, if applicable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- Explain the problem and the outcome of this change. -->
+
+## Changes
+
+-
+
+## Verification
+
+<!-- List exact commands and manual checks. Say what could not be run and why. -->
+
+```text
+
+```
+
+## Security, privacy, and compatibility
+
+<!-- Cover permissions, tokens, paths, commands, persistence/migrations, MCP/API contracts, public exposure, browser behavior, and breaking changes. Write "None" only after reviewing them. -->
+
+## Screenshots
+
+<!-- Required for visible UI changes. Redact private information. -->
+
+## Checklist
+
+- [ ] The change is focused and targets `dev` unless a maintainer requested otherwise.
+- [ ] Tests were added or updated for observable behavior.
+- [ ] Rust formatting/Clippy and frontend lint/tests/build were run as applicable.
+- [ ] User-facing and protocol documentation was updated.
+- [ ] English and Vietnamese UI strings remain aligned.
+- [ ] No secret, private data, generated output, database, log, or source map is included.
+- [ ] I have the right to submit this contribution under the MIT License.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to ChatCMD are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project intends to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once stable public releases are tagged.
+
+## [Unreleased]
+
+### Added
+
+- MIT licensing and package license metadata.
+- Open-source contribution, conduct, security, support, governance, and release documentation.
+- GitHub issue and pull-request templates.
+- Comprehensive project, architecture, development, plugin-setup, and troubleshooting guides.
+
+### Changed
+
+- Replaced the minimal README with a complete international English project guide.
+
+Release history will be added here when versions are tagged. Earlier repository history remains available through Git.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our commitment
+
+We are committed to making participation in ChatCMD a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity or expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We will act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Expected behavior
+
+Examples of behavior that contributes to a positive community include:
+
+- showing empathy and respect for different viewpoints and experiences;
+- giving and accepting constructive feedback gracefully;
+- focusing criticism on ideas and code rather than people;
+- accepting responsibility, apologizing, and learning from mistakes;
+- prioritizing the health of the project and community over individual preference.
+
+## Unacceptable behavior
+
+Unacceptable behavior includes:
+
+- sexualized language or imagery, sexual attention, or advances;
+- trolling, insulting or derogatory comments, and personal or political attacks;
+- public or private harassment;
+- publishing another person's private information without explicit permission;
+- threats, intimidation, stalking, or encouraging any of these behaviors;
+- conduct that would reasonably be considered inappropriate in a professional setting.
+
+## Scope
+
+This code applies in project spaces and when an individual officially represents the project in public spaces. Project spaces include issues, pull requests, discussions, reviews, commits, and other community channels.
+
+## Reporting and enforcement
+
+Report abusive, harassing, or otherwise unacceptable behavior privately to the maintainers using a non-public contact method listed on the [maintainer's GitHub profile](https://github.com/int04). Do not include sensitive personal information in a public issue.
+
+Maintainers will review reports fairly and as confidentially as practical. They may remove or edit content, reject contributions, issue a warning, temporarily restrict participation, or permanently ban a participant. A maintainer with a conflict of interest must not be the sole decision-maker for that report.
+
+Retaliation against anyone who makes a good-faith report is not permitted.
+
+## Attribution
+
+This policy is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to ChatCMD
+
+Thank you for helping improve ChatCMD. Contributions of code, tests, documentation, design, translations, bug reports, and reproducible investigations are welcome.
+
+By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Before you start
+
+- Search the [issue tracker](https://github.com/int04/ChatCmdClient/issues) before opening a duplicate.
+- Use a public issue for bugs and feature discussions, but follow [SECURITY.md](SECURITY.md) for vulnerabilities.
+- Discuss large changes before implementation. This reduces duplicated work and helps align the design with the local-first security model.
+- Keep a pull request focused on one problem. Unrelated refactors make review and rollback harder.
+
+## Branch policy
+
+- `main` is the stable integration branch.
+- `dev` is the normal target for active development pull requests.
+- Maintainers promote reviewed changes from `dev` to `main` for stable releases.
+
+Unless a maintainer requests otherwise, branch from the latest `dev` and open the pull request against `dev`.
+
+## Development setup
+
+Follow [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for prerequisites, local commands, repository layout, and test suites.
+
+The shortest setup is:
+
+```bash
+git clone https://github.com/int04/ChatCmdClient.git
+cd ChatCmdClient
+git switch dev
+cd web
+npm ci
+npm run build
+cd ..
+cargo run
+```
+
+## Making a change
+
+1. Create a topic branch from `dev`.
+2. Add or update tests for observable behavior.
+3. Update user-facing or protocol documentation when behavior changes.
+4. Run formatters, linters, tests, and builds appropriate to the affected area.
+5. Review the final diff for secrets, generated files, unrelated changes, and accidental debug output.
+6. Open a pull request using the repository template.
+
+Do not commit:
+
+- MCP endpoint tokens, cookies, API keys, signing credentials, personal paths, or private conversation content;
+- `target/`, `web/node_modules/`, `web/dist/`, `release/`, runtime logs, or local SQLite databases;
+- minified/obfuscated release output when the source file is already tracked.
+
+## Engineering expectations
+
+- Preserve the local-first architecture and least-privilege defaults.
+- Keep operations bounded in time, memory, output size, and filesystem scope.
+- Prefer structured arguments over shell interpolation.
+- Treat destructive filesystem, process, Git, and terminal operations as security-sensitive.
+- Preserve token redaction and avoid logging user content unless it is required for diagnosis.
+- Maintain backward compatibility for persisted data and public MCP contracts, or document an explicit migration.
+- Keep English and Vietnamese UI strings aligned when adding user-visible text.
+- Update `docs/mcp_method.md` whenever the exposed tool catalog changes.
+
+## Verification
+
+Run the complete suite when practical:
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --all-targets
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+
+cd web
+npm ci
+npm run lint
+npm test -- --run
+npm run build
+
+cd ../chatgpt-extension
+node --test content-chatgpt.test.cjs
+```
+
+If a platform-specific command cannot run on your machine, state that clearly in the pull request and include the commands you did run.
+
+## Pull request review
+
+A pull request should explain:
+
+- the user or maintainer problem;
+- the approach and important trade-offs;
+- security, privacy, persistence, and compatibility impact;
+- verification performed;
+- screenshots or recordings for visible UI changes.
+
+Maintainers may request smaller commits, additional tests, documentation, or a design discussion. Approval does not guarantee an immediate release.
+
+## Licensing
+
+The project is licensed under the [MIT License](LICENSE). By submitting a contribution, you agree that your contribution may be distributed under that license and that you have the right to submit it.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,11 @@
+# Contributors
+
+ChatCMD is maintained by [Nghia Duc (`@int04`)](https://github.com/int04) with help from everyone who contributes code, tests, documentation, translations, design feedback, and issue investigations.
+
+Git remains the authoritative record of code and documentation authorship:
+
+```bash
+git shortlog --summary --numbered --email --all
+```
+
+New contributors are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "chat-cmd-client"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
+description = "A local-first MCP bridge between web AI clients and your computer"
+license = "MIT"
+repository = "https://github.com/int04/ChatCmdClient"
+homepage = "https://chatcmd.net"
+readme = "README.md"
+publish = false
 
 [workspace]
 members = [

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,38 @@
+# Governance
+
+ChatCMD currently follows a maintainer-led governance model designed for a small open-source project.
+
+## Roles
+
+### Contributors
+
+Anyone who submits useful issues, documentation, code, tests, design work, translations, or reviews is a contributor.
+
+### Reviewers
+
+Reviewers are trusted contributors who regularly provide technically sound reviews in one or more areas. They may triage issues and recommend changes but do not merge without repository permission.
+
+### Maintainers
+
+Maintainers set release direction, protect the project's security and compatibility boundaries, review and merge contributions, manage releases, and enforce community policies. The current lead maintainer is [Nghia Duc (`@int04`)](https://github.com/int04).
+
+## Decision process
+
+- Routine fixes and documentation changes are decided through pull-request review.
+- Significant protocol, security, persistence, compatibility, or architecture changes should begin with a public proposal issue.
+- Maintainers seek practical consensus and document important trade-offs.
+- When consensus cannot be reached in a reasonable time, the lead maintainer makes the final decision and explains it publicly when security or confidentiality does not prevent that.
+
+Security embargoes, private conduct reports, legal matters, and unreleased credentials may be handled privately.
+
+## Becoming a reviewer or maintainer
+
+There is no application quota or required employment relationship. Maintainers consider sustained high-quality contributions, sound security judgment, respectful collaboration, review participation, and familiarity with the architecture. Access can be reduced or removed for inactivity, security needs, policy violations, or conflicts of interest.
+
+## Branches and releases
+
+- `dev` is the normal active-development and pull-request branch.
+- `main` represents stable integrated code.
+- Releases are tagged from reviewed stable history and documented in [CHANGELOG.md](CHANGELOG.md).
+
+This model may evolve as the contributor community grows. Governance changes should be proposed and reviewed like other significant project changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nghia Duc and ChatCMD contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,266 @@
-# ChatCmdClient
+# ChatCMD
 
-ChatCmdClient is a local-only bridge between AI clients, MCP, a bounded machine runtime, SQLite, and a React/Vite management UI. It has no SaaS account, quota, payment, or remote authentication dependency.
+<p align="center">
+  <img src="assets/icons/logo-transparent-master-1254.png" alt="ChatCMD logo" title="ChatCMD" width="420">
+</p>
 
-## Run
+<p align="center">
+  Turn web-based AI into a local worker through the Model Context Protocol.
+</p>
 
-Requirements: stable Rust, Node.js/npm, Git, and a supported local shell.
+<p align="center">
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-2ea44f.svg"></a>
+  <a href="Cargo.toml"><img alt="Rust 1.85 or newer" src="https://img.shields.io/badge/Rust-1.85%2B-dea584.svg"></a>
+  <a href="web/package.json"><img alt="React and Vite" src="https://img.shields.io/badge/UI-React%20%2B%20Vite-646cff.svg"></a>
+  <a href="https://modelcontextprotocol.io/"><img alt="Model Context Protocol" src="https://img.shields.io/badge/Protocol-MCP-5a45ff.svg"></a>
+</p>
 
-```powershell
-cd web
+ChatCMD is a self-hosted bridge between MCP-compatible AI clients and your computer. It combines a Rust server, a permission-scoped machine runtime, SQLite persistence, a React management console, and an optional Chromium extension for working with ChatGPT in the browser.
+
+The core application runs on your machine. It has no ChatCMD account, subscription, payment, quota, or hosted authentication dependency. Optional features can still make outbound connections—for example to ChatGPT, a Git repository used to install a skill, a Google Font, or a tunnel address that you configure.
+
+> [!CAUTION]
+> ChatCMD can expose terminals, files, Git repositories, and local processes to an AI client. Start with the smallest tool allowlist, keep approval mode enabled, review every public endpoint, and never publish a tokenized MCP URL.
+
+## Why ChatCMD
+
+- **Local-first runtime:** the server, management UI, task history, settings, and SQLite database stay on your device.
+- **MCP access profiles:** create multiple plugin profiles, grant tools per profile, disable access without deleting the profile, and rotate secret URLs.
+- **Real machine tools:** persistent PTY terminals, bounded file operations, Git commands, process inspection, task artifacts, and skill discovery.
+- **Live supervision:** follow progress, tool calls, file changes, terminals, sub-agents, approvals, and final responses in real time.
+- **ChatGPT web bridge:** optionally send, continue, queue, and stop ChatGPT browser conversations through a Manifest V3 extension.
+- **Cross-platform codebase:** Windows, macOS, and Linux development/runtime support; release packaging scripts are included for Windows and macOS.
+- **No vendor lock-in:** the server uses MCP Streamable HTTP and a documented local API rather than a proprietary hosted control plane.
+
+## Features
+
+### MCP and permissions
+
+- Tokenized Streamable HTTP endpoints in the form `http://127.0.0.1:8080/mcp/<token>`.
+- Separate access profiles for different AI clients or jobs.
+- Per-tool allowlists, grouped permission controls, and a non-destructive preset.
+- Enable, disable, edit, delete, and rotate access profiles.
+- Origin and host validation, one-time local profile secrets hashed at rest, URL-token redaction in built-in HTTP traces, and rejection of query-string credentials.
+- User-managed public domains, reverse proxies, IP addresses, and tunnels with a connectivity test before they are saved.
+
+### Local tool catalog
+
+| Group | Capabilities |
+| --- | --- |
+| Device | List and inspect the local execution device. |
+| Terminal | Create, write, wait, read, signal, resize, list, inspect, and close persistent PTY sessions. |
+| Files and workspace | Discover roots; list, find, search, read, create, replace, write, inspect, copy, move, and delete files or directories. |
+| Git | Status, diff, log, branches, show revisions, and create commits without shell interpolation. |
+| Processes | List, inspect, and terminate local processes or process trees. |
+| Skills | Discover and read project or user skills from `.agents` and `.codex`. |
+| Tasks and orchestration | Track user turns, progress, execution mode, artifacts, plan questions, sub-agents, waits, and completion. |
+
+The authoritative method-by-method reference is in [docs/mcp_method.md](docs/mcp_method.md).
+
+### Management console
+
+- Runtime dashboard for app, database, MCP listener, task, terminal, approval, and client health.
+- Project-aware task rail with search, pagination, rename, delete, unread counters, and workspace grouping.
+- Rich task timeline with Markdown, tool output, syntax highlighting, file-change summaries, side-by-side diffs, sub-agent status, and stop controls.
+- Conversation, activity, and plan-question approval queues.
+- Interactive xterm.js terminal views with live output, input, resize, process ID, CPU, and memory information.
+- Skill discovery, enable/disable controls, configurable skill options, GitHub repository preview, installation, and removal.
+- English and Vietnamese UI, light/dark/system themes, configurable Google Fonts, task font scaling, and event sounds.
+- SQLite diagnostics, application logs, extension logs, configurable data retention, and selective user-data cleanup.
+- Windows/macOS system tray behavior and an optional elevated restart flow.
+
+### ChatGPT browser bridge
+
+The optional `chatgpt-extension/` package can use an already signed-in `chatgpt.com` tab to:
+
+- start or continue a browser conversation from ChatCMD;
+- choose a visible ChatGPT model label;
+- queue, reorder, edit, send immediately, or delete follow-up messages;
+- stop an active generation;
+- relay final responses and conversation identity back to the local task;
+- show local conversation, tool, and plan-question approvals in ChatGPT;
+- provide a browser fallback for sub-agent work.
+
+This extension is an unofficial DOM bridge, not the OpenAI API. ChatGPT UI changes may require selector updates. See [chatgpt-extension/README.md](chatgpt-extension/README.md) for its security model and limitations.
+
+ChatCMD is an independent project and is not affiliated with or endorsed by OpenAI, ChatGPT, Cloudflare, or other third-party service providers. Their names and trademarks belong to their respective owners, and use of their services remains subject to their terms.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    AI["MCP client / web AI"] -->|"tokenized MCP URL"| MCP["Rust MCP server"]
+    GPT["ChatGPT tab"] <--> EXT["Optional browser extension"]
+    EXT <--> API["Encrypted local API + WebSocket"]
+    UI["React management console"] <--> API
+    MCP --> RT["Bounded local runtime"]
+    API --> RT
+    RT --> OS["PTY · files · Git · processes · skills"]
+    MCP --> DB[("SQLite")]
+    API --> DB
+```
+
+For component boundaries, data flow, and security assumptions, read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Requirements
+
+- [Rust](https://www.rust-lang.org/tools/install) **1.85 or newer** with Cargo.
+- [Node.js](https://nodejs.org/) **20.19 or newer**, or **22.12 or newer**, and npm (matching the checked-in Vite engine requirement).
+- [Git](https://git-scm.com/).
+- A supported local shell: PowerShell or `cmd.exe` on Windows; `bash` or `zsh` on macOS/Linux.
+- Platform build tools:
+  - Windows: Visual Studio Build Tools with the MSVC C++ workload.
+  - macOS: Xcode Command Line Tools.
+  - Linux: a C/C++ toolchain and the platform packages required by `winit`/`tray-icon` dependencies when building desktop targets.
+
+## Quick start from source
+
+```bash
+git clone https://github.com/int04/ChatCmdClient.git
+cd ChatCmdClient/web
 npm ci
 npm run build
 cd ..
 cargo run
 ```
 
-Open `http://127.0.0.1:8080`. The listener defaults to `127.0.0.1:8080`. Override it with `CHATCMD_BIND` and `CHATCMD_PORT`; exposing a non-loopback address disables origin-less MCP clients. Override the database with `CHATCMD_DB_PATH`.
+Open <http://127.0.0.1:8080>. The first start creates and migrates the local SQLite database automatically.
 
-Default SQLite paths:
+For frontend hot reload, run the backend and Vite separately:
+
+```bash
+# Terminal 1, repository root
+cargo run
+
+# Terminal 2
+cd web
+npm ci
+npm run dev
+```
+
+Then open <http://127.0.0.1:5173>. Vite proxies `/api` and `/ws` to the Rust server on port `8080`.
+
+## Connect an MCP client
+
+1. Open **Plugin list** in ChatCMD and select **Create new Plugin connection**.
+2. Give the profile a recognizable name.
+3. Select only the tool groups required for that client, then save the profile.
+4. For a local MCP client, choose **Create new access code** from the profile menu and save the one-time endpoint immediately.
+5. Add that URL as a Streamable HTTP MCP server in the client. No `Authorization` header is required; the secret is the final URL path segment.
+
+To connect a web-hosted AI through your own public endpoint, follow [docs/PLUGIN_SETUP.md](docs/PLUGIN_SETUP.md). It covers tunnel/reverse-proxy setup, the ChatGPT developer-mode flow, and installation of the optional browser extension.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CHATCMD_BIND` | `127.0.0.1` | Listener IP address. Keep loopback unless you understand the exposure and origin-policy consequences. |
+| `CHATCMD_PORT` | `8080` | HTTP, MCP, API, UI, and WebSocket port. |
+| `CHATCMD_DB_PATH` | Platform data directory | Override the SQLite database path. |
+| `CHATCMD_WEB_DIST` | `web/dist` | Use a different built frontend directory for non-embedded development builds. |
+| `CHATCMD_LOG_PATH` | `logs/chatcmd.log` | Override the append-only diagnostic log path. |
+| `CHATCMD_FINALIZATION_GRACE_SECONDS` | `120` | Auto-finalization grace period, clamped to 30–3,600 seconds. |
+| `CHATCMD_BUILD_VERSION` | Cargo package version | Version embedded into a build or release package. |
+| `RUST_LOG` | `chat_cmd_client=info,tower_http=info` | Configure Rust tracing filters. |
+
+Default database locations:
 
 - Windows: `%LOCALAPPDATA%\ChatCmdClient\data\chatcmd.db`
 - macOS: `~/Library/Application Support/ChatCmdClient/chatcmd.db`
 - Linux: `$XDG_DATA_HOME/chatcmd-client/chatcmd.db`, or `~/.local/share/chatcmd-client/chatcmd.db`
 
-Startup is idempotent. Stale running tasks and terminal sessions become `interrupted` after restart.
+Startup is idempotent. After a restart, stale running tasks and terminal sessions are marked interrupted.
 
-## MCP
+## Build release artifacts
 
-Endpoint format: `http://127.0.0.1:8080/mcp/{token}`
+Create a standalone binary with the frontend embedded:
 
-Create an agent in the UI, select its allowed tools, then save the returned MCP URL immediately. The generated token is embedded as the final path segment. No `Authorization` header is used or required. The complete tokenized URL appears only after create or rotate and is never returned by list/get APIs.
-
-```text
-http://127.0.0.1:8080/mcp/<one-time-token>
+```bash
+cd web
+npm ci
+npm run build
+cd ..
+cargo build --release --features embedded-web
 ```
 
-Browser origins are restricted to `localhost` or `127.0.0.1` on the configured port. Native MCP clients may omit `Origin` only while the server is bound to a loopback address. Query-string tokens (`token`, `access_token`, `bearer_token`) are rejected. The built-in HTTP trace masks `/mcp/{token}`, but client history and external proxy logs may still expose a URL token, so keep the endpoint local and private.
-
-Management API requests require `X-ChatCmdClient: local-ui`. Static files, WebSocket, health/info, and MCP do not require this UI marker. No permissive CORS layer is enabled.
-
-## Verify
+Maintainers can use the packaging scripts:
 
 ```powershell
+# Windows x64 and x86
+.\scripts\build-windows.ps1 -Version 0.1.0
+```
+
+```bash
+# macOS Apple Silicon and Intel
+CHATCMD_BUILD_VERSION=0.1.0 ./scripts/build-macos.sh
+```
+
+The macOS script supports `MACOS_SIGN_IDENTITY` and `MACOS_NOTARY_PROFILE`. Full release instructions are in [docs/RELEASING.md](docs/RELEASING.md).
+
+## Verify a change
+
+```bash
 cargo fmt --all -- --check
 cargo check --workspace --all-targets
 cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
+
 cd web
 npm ci
 npm run lint
 npm test -- --run
 npm run build
+
+cd ../chatgpt-extension
+node --test content-chatgpt.test.cjs
 ```
+
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for the contributor workflow and narrower test commands.
+
+## Screenshots
+
+### Runtime overview
+
+### Tasks and real-time activity
+
+### Plugin access profiles
+
+### Interactive terminals
+
+### Skills management
+
+### Settings and diagnostics
+
+## Security and privacy
+
+- Treat every MCP URL as a password. The full tokenized URL can grant the profile's permissions to anyone who has it.
+- Local profile secrets are stored as hashes. Public plugin-link tokens are stored in the local SQLite database in recoverable plaintext so ChatCMD can copy the same link again; protect the database with operating-system account and disk controls.
+- Prefer loopback binding and an authenticated, HTTPS tunnel or reverse proxy for remote access.
+- The local management API requires a trusted caller marker and encrypts JSON bodies; the WebSocket uses an ephemeral ECDH-derived AES-GCM session. This is defense in depth, not protection from the owner of a compromised browser or machine.
+- The extension has no cookie permission and does not read or write ChatGPT login tokens, but it can interact with the signed-in ChatGPT page through its DOM.
+- Review [SECURITY.md](SECURITY.md) before reporting a vulnerability. Do not place secrets or private data in a public issue.
+
+## Documentation
+
+- [Documentation index](docs/README.md)
+- [Plugin and ChatGPT setup](docs/PLUGIN_SETUP.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Development guide](docs/DEVELOPMENT.md)
+- [Open-source publication checklist](docs/OPEN_SOURCE_CHECKLIST.md)
+- [MCP method reference](docs/mcp_method.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [Encryption protocol](docs/ENCRYPTION_PROTOCOL.md)
+- [Diagnostic logs](docs/logs.md)
+- [Release guide](docs/RELEASING.md)
+
+## Contributing
+
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md), the [Code of Conduct](CODE_OF_CONDUCT.md), and [GOVERNANCE.md](GOVERNANCE.md) before opening a pull request. Use [SUPPORT.md](SUPPORT.md) to choose the right support channel.
+
+## License
+
+ChatCMD is available under the [MIT License](LICENSE). You may use, copy, modify, distribute, sublicense, and sell copies, including as part of commercial products, subject to the license notice and warranty disclaimer.
+
+Third-party dependencies, services, trademarks, and bundled media remain subject to their own licenses and terms.
+
+Copyright © 2026 Nghia Duc and ChatCMD contributors.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,18 @@
+# Roadmap
+
+ChatCMD's direction is to make locally supervised AI work safer, more observable, and more reliable on large real-world projects.
+
+Current focus areas include:
+
+- bounded and cancellable filesystem, terminal, Git, and process operations;
+- scalable file reading, listing, finding, and content search;
+- stronger approval, least-privilege, token, tunnel, and path-safety controls;
+- reliable task, sub-agent, finalization, and recovery lifecycles;
+- compact persistence and real-time events for large outputs and artifacts;
+- actionable runtime, database, terminal, tool, and extension observability;
+- cross-platform packaging and maintainable ChatGPT browser integration;
+- stable MCP schemas, generated catalog consistency, and compatibility testing.
+
+Detailed engineering proposals live in [`plan/`](plan/). A plan document describes intent and risks; it is not a promise that the work is scheduled or complete. Issues, pull requests, security findings, and maintainer capacity may change priorities.
+
+For a proposal, open an issue describing the user problem, security and compatibility impact, alternatives considered, and a practical validation strategy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+ChatCMD intentionally gives AI clients controlled access to terminals, files, Git repositories, processes, tasks, and other local resources. Security reports are taken seriously.
+
+## Supported versions
+
+| Version | Supported |
+| --- | --- |
+| Latest release on `main` | Yes |
+| Current `dev` branch | Best effort |
+| Older releases or forks | No |
+
+Security fixes are normally prepared for the latest maintained code. Maintainers may choose to backport a critical fix, but no backport is guaranteed.
+
+## Report a vulnerability privately
+
+Do not open a public issue for a suspected vulnerability and do not include live secrets, private files, or conversation data in a public report.
+
+Use [GitHub's private vulnerability reporting form](https://github.com/int04/ChatCmdClient/security/advisories/new). If private reporting is unavailable, contact the maintainer through a non-public method listed on the [maintainer's GitHub profile](https://github.com/int04).
+
+Include, when available:
+
+- affected version, commit, operating system, and browser;
+- required configuration and whether the server was loopback-only or publicly reachable;
+- a minimal reproduction or proof of concept;
+- expected and observed behavior;
+- realistic impact and attack preconditions;
+- suggested mitigation;
+- whether any token, key, personal data, or third-party account may have been exposed.
+
+Use dummy credentials and minimal test data. Do not access data that you do not own or have explicit permission to test.
+
+## Coordinated disclosure
+
+Maintainers will acknowledge the report when possible, validate it, establish severity and affected versions, and coordinate a fix and disclosure. Please allow reasonable remediation time before publishing details. Credit will be given if requested unless doing so would expose sensitive information.
+
+## High-value areas
+
+Reports are especially useful for:
+
+- bypassing MCP profile authentication or per-tool authorization;
+- leaking or recovering raw MCP tokens from storage, logs, API responses, or UI history;
+- origin, host-header, tunnel, reverse-proxy, or local-management API bypasses;
+- escaping canonical workspace or path restrictions, including through symlinks or race conditions;
+- command or argument injection in shell, Git, process, folder-picker, or packaging flows;
+- unauthorized browser-extension access to cookies, login tokens, tabs, conversations, or non-local callbacks;
+- approval bypasses, confused-deputy behavior, sub-agent privilege escalation, or cross-task data leakage;
+- unsafe deserialization, migration, encryption, or secret-handling behavior;
+- denial of service caused by unbounded input, traversal, output, persistence, or concurrency.
+
+## Security assumptions and exclusions
+
+- A tokenized MCP endpoint is a bearer secret. Possession of the URL grants the access profile's allowed tools.
+- The optional ChatGPT extension controls the DOM of an already signed-in tab. A malicious browser extension, compromised browser profile, or local administrator is outside its trust boundary.
+- Local API and WebSocket encryption is defense in depth against casual inspection. It cannot protect plaintext from code executing inside the same browser or a compromised machine.
+- Public exposure through a tunnel or port forward changes the threat model. Operators are responsible for HTTPS, tunnel access policy, firewalling, endpoint secrecy, and third-party terms.
+- Social engineering, unsupported versions, deliberately disabled security controls, and vulnerabilities that require prior full control of the same operating-system account may be closed as out of scope unless they create a meaningful new boundary violation.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/ENCRYPTION_PROTOCOL.md](docs/ENCRYPTION_PROTOCOL.md) for implementation details.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support
+
+ChatCMD is a community-maintained open-source project. Support is provided on a best-effort basis and does not include a guaranteed response or resolution time.
+
+## Start here
+
+1. Read the [README](README.md) and [documentation index](docs/README.md).
+2. Check [Troubleshooting](docs/TROUBLESHOOTING.md).
+3. Search [existing issues](https://github.com/int04/ChatCmdClient/issues).
+4. Reproduce the problem with the latest supported version if possible.
+
+## Open an issue
+
+Use the issue templates for reproducible bugs, feature proposals, or documentation problems. Include the application version or commit, operating system, browser/extension version when relevant, configuration with secrets removed, reproduction steps, expected behavior, actual behavior, and verification already attempted.
+
+Logs may contain paths or user-generated content. Review and redact them before posting. Never publish an MCP endpoint token, cookie, API key, signing identity, private conversation, or proprietary source code.
+
+## Security reports
+
+Potential vulnerabilities must follow [SECURITY.md](SECURITY.md) and must not be reported in a public issue.
+
+## Questions and project proposals
+
+For usage questions that are not bugs, open a GitHub discussion if Discussions are enabled. Otherwise, use a clearly labeled issue. For substantial design changes, open a proposal issue before investing in a large implementation.
+
+## Commercial support
+
+The MIT license permits commercial use, but this repository does not include a commercial support agreement, uptime commitment, warranty, or service-level agreement.

--- a/chatgpt-extension/README.md
+++ b/chatgpt-extension/README.md
@@ -1,28 +1,81 @@
 # ChatCMD ChatGPT Bridge
 
-Extension Manifest V3 cho Chrome/Edge, dùng tab `chatgpt.com` mà người dùng đã đăng nhập để gửi/tiếp tục/dừng tin nhắn từ ChatCMD local web.
+ChatCMD ChatGPT Bridge is an optional Chromium Manifest V3 extension that connects the local ChatCMD console to an already signed-in `chatgpt.com` tab.
 
-## Cài development
+It is an unofficial browser UI integration, not the OpenAI API and not a replacement for a normal MCP connection. It automates the current ChatGPT page DOM in the same browser profile as the user.
 
-1. Mở `chrome://extensions` hoặc `edge://extensions`.
-2. Bật **Developer mode**.
-3. Chọn **Load unpacked**.
-4. Chọn folder `chatgpt-extension` này.
-5. Đăng nhập `https://chatgpt.com` trong cùng profile trình duyệt.
-6. Reload trang ChatCMD local web rồi vào **Tasks → Tin nhắn mới**.
+## Capabilities
 
-## Quyền và bảo mật
+- Start a ChatGPT conversation from the local ChatCMD UI.
+- Continue an existing conversation while retaining its browser identity.
+- Select a model by its visible ChatGPT label.
+- Queue, reorder, edit, send immediately, or delete follow-up messages.
+- Stop an active response.
+- Relay assistant output and conversation URLs to the matching local task.
+- Surface ChatCMD conversation, tool, and plan-question approvals in ChatGPT.
+- Provide a browser fallback for sub-agent work when host sampling is unavailable.
+- Keep bounded diagnostic logs in extension storage for local troubleshooting.
 
-- Extension **không** có quyền `cookies` và không đọc/ghi token đăng nhập.
-- Nó thao tác DOM của trang ChatGPT đang đăng nhập, tương tự thao tác của người dùng.
-- Nếu chưa có tab ChatGPT, bridge tạo tab nền không giành focus và tự đóng tab đó sau khi request hoàn tất; tab ChatGPT do người dùng mở sẵn sẽ chỉ được tái sử dụng và không tự đóng.
-- Callback chỉ được gửi tới HTTP origin `localhost` hoặc `127.0.0.1` và luôn kèm `X-ChatCmdClient: chatgpt-extension`.
-- Selector ChatGPT được cô lập trong `content-chatgpt.js`; nếu ChatGPT đổi UI thì sửa adapter này.
+## Install for development
 
-## Model
+1. Start ChatCMD on `http://127.0.0.1:8080` or `http://localhost:8080`.
+2. Open `chrome://extensions/`, `edge://extensions/`, or `brave://extensions/`.
+3. Enable **Developer mode**.
+4. Select **Load unpacked**.
+5. Choose this `chatgpt-extension` directory.
+6. Sign in to <https://chatgpt.com> in the same browser profile.
+7. Reload the ChatGPT and local ChatCMD pages.
 
-`Auto` giữ nguyên model hiện tại của ChatGPT. Với model khác, extension mở model switcher và chọn theo text hiển thị. Tên model trên ChatGPT có thể thay đổi theo tài khoản/plan, vì vậy ô model trong ChatCMD cho phép nhập label tùy ý.
+For the complete MCP profile, public address, ChatGPT plugin, and extension workflow, read [Plugin and ChatGPT setup](../docs/PLUGIN_SETUP.md).
 
-## Lưu ý
+## Permissions and trust model
 
-Đây là browser UI bridge, không phải OpenAI API chính thức. Việc gửi và đọc phản hồi phụ thuộc vào DOM hiện tại của `chatgpt.com`; nên kiểm thử lại extension sau các thay đổi lớn của giao diện ChatGPT.
+The manifest requests:
+
+- `tabs` to find, open, focus, and close ChatGPT conversation tabs;
+- `storage` for conversation bindings, request context, preferences, and bounded diagnostics;
+- `scripting` to restore content scripts after extension or page lifecycle changes;
+- host access to `https://chatgpt.com/*` and local HTTP `localhost`/`127.0.0.1` origins.
+
+The extension does **not** request the `cookies` permission and does not read or write ChatGPT login tokens. It can still read and interact with the visible ChatGPT page because that is its purpose. Use a dedicated browser profile if stronger separation is required.
+
+Callbacks are restricted to local HTTP origins and include:
+
+```text
+X-ChatCmdClient: chatgpt-extension
+```
+
+The approval WebSocket uses the same ephemeral encrypted session model as the local UI. This does not protect data from a compromised browser profile, malicious extension, injected page code, or local administrator.
+
+## Tab behavior
+
+- An existing ChatGPT conversation tab is reused when possible.
+- If ChatCMD creates a background tab for a request, the extension can close that generated tab after completion.
+- A tab that the user already had open is not automatically closed.
+- Conversation IDs and provisional-to-final URL aliases are stored so follow-up messages return to the correct tab.
+
+## Model selection
+
+`Auto` keeps the current/default ChatGPT model. For another value, the extension opens the model switcher and selects the visible label. Available names depend on the account, workspace, plan, and current ChatGPT UI, so ChatCMD accepts a custom label.
+
+## Diagnostics
+
+Open **ChatCMD → Settings → Data & logs → Extension logs**. For background failures, also inspect the extension service worker from the browser extensions page.
+
+Logs and bug reports must not contain private conversations, MCP endpoints, cookies, credentials, or proprietary source data.
+
+## Test
+
+```bash
+node --test content-chatgpt.test.cjs
+```
+
+The automated suite covers DOM-adapter behavior with fixtures. After changing selectors or message flow, manually verify start, continue, model selection, stop, approvals, queue handling, tab reuse, and final-response capture in a disposable browser profile.
+
+## Maintenance limitation
+
+ChatGPT's page structure, labels, and interaction behavior can change without notice. Selectors are split across `content-chatgpt-ui.js`, `content-chatgpt-dom.js`, `content-chatgpt-approval-ui.js`, and `content-chatgpt.js` to keep updates localized, but every significant ChatGPT UI change should trigger a manual compatibility test.
+
+## License
+
+This extension is part of ChatCMD and is distributed under the repository's [MIT License](../LICENSE).

--- a/crates/chatcmd-core/Cargo.toml
+++ b/crates/chatcmd-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "chatcmd-core"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
+license = "MIT"
 publish = false
 
 [features]

--- a/crates/chatcmd-mcp/Cargo.toml
+++ b/crates/chatcmd-mcp/Cargo.toml
@@ -2,6 +2,8 @@
 name = "chatcmd-mcp"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
+license = "MIT"
 publish = false
 
 [dependencies]

--- a/crates/chatcmd-runtime/Cargo.toml
+++ b/crates/chatcmd-runtime/Cargo.toml
@@ -2,6 +2,8 @@
 name = "chatcmd-runtime"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
+license = "MIT"
 publish = false
 
 [dependencies]

--- a/crates/chatcmd-storage/Cargo.toml
+++ b/crates/chatcmd-storage/Cargo.toml
@@ -3,6 +3,7 @@ name = "chatcmd-storage"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
+license = "MIT"
 publish = false
 
 [dependencies]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,132 @@
+# Architecture
+
+ChatCMD is a local-first Rust application with an embedded or separately served React UI. It exposes an authenticated MCP endpoint to AI clients and translates allowed tool calls into bounded local runtime operations.
+
+## System context
+
+```mermaid
+flowchart TB
+    Client["MCP-compatible AI client"] -->|"Streamable HTTP + URL token"| Server["ChatCMD Rust server"]
+    Browser["Signed-in ChatGPT tab"] <--> Extension["Optional MV3 extension"]
+    Extension <--> Local["Local API / encrypted WebSocket"]
+    Console["React management console"] <--> Local
+    Server --> Host["Runtime host"]
+    Local --> Host
+    Host --> Runtime["PTY · filesystem · Git · process · skills"]
+    Host --> Storage[("SQLite")]
+    Server --> Storage
+```
+
+## Repository layout
+
+| Path | Responsibility |
+| --- | --- |
+| `src/` | Application startup, HTTP routes, local API, WebSocket, runtime orchestration, task lifecycle, and desktop tray. |
+| `crates/chatcmd-core/` | Shared domain models, store traits, secret wrappers, identifiers, and contracts. |
+| `crates/chatcmd-storage/` | SQLite repository, migrations, device identity, event writer, recovery, and legacy import. |
+| `crates/chatcmd-runtime/` | Policy-aware filesystem, PTY shell, Git, process, workspace, and skill services. |
+| `crates/chatcmd-mcp/` | MCP schemas, tool router, authentication/origin enforcement, request identity, and sub-agent sampling protocol. |
+| `web/` | React/Vite management console, encrypted API client, real-time state, task UI, and tests. |
+| `chatgpt-extension/` | Chromium Manifest V3 bridge for an existing ChatGPT browser session. |
+| `scripts/` | Windows and macOS release packaging. |
+| `docs/` | User, protocol, architecture, and maintenance documentation. |
+| `plan/` | Design proposals for scalability, safety, and protocol evolution. |
+
+## Startup lifecycle
+
+1. `src/main.rs` reads bind, port, database, logging, and frontend configuration.
+2. `chatcmd-storage` resolves the platform data path, opens SQLite, applies migrations, and restores stable device identity.
+3. Startup recovery marks stale running tasks and terminal sessions as interrupted.
+4. The current MCP tool catalog and permission preset are seeded into SQLite.
+5. ChatCMD creates the policy engine and the workspace, shell, Git, process, and skill services.
+6. `RuntimeHost` connects those services to task identity, approvals, sub-agents, persistence, and real-time events.
+7. Axum mounts the MCP router, health endpoints, encrypted local management API, WebSocket, and frontend assets on one listener.
+8. Release builds on Windows and macOS start the server behind a tray application; development builds run directly.
+
+## MCP request flow
+
+```text
+POST /mcp/<token>
+  -> host validation
+  -> query-token rejection
+  -> URL-token hash lookup
+  -> enabled access profile + tool allowlist
+  -> MCP schema validation
+  -> server-derived agent/session identity
+  -> RuntimeHost dispatch
+  -> policy / approval / cancellation checks
+  -> local service operation
+  -> SQLite event persistence + WebSocket publication
+  -> MCP result
+```
+
+The raw local profile secret is generated for one-time display and only a derived hash plus a short suffix are persisted. A separate token is generated for public plugin links. Public plugin tokens are stored in recoverable plaintext in the local SQLite database so the UI can reproduce the same public link, alongside a hash used for lookup. Every URL token is a bearer credential and must be handled like a password.
+
+MCP tools are grouped into device, terminal, filesystem/workspace, Git, process, skill, task, and agent-orchestration capabilities. The server identity—not untrusted request fields—selects the effective access profile.
+
+## Local management flow
+
+The management UI communicates with `/api/local/*`. Requests require `X-ChatCmdClient: local-ui`; extension callbacks use the narrower `chatgpt-extension` marker. Health and version endpoints remain outside this protected route group.
+
+The browser establishes an ephemeral P-256 ECDH session, derives an AES-256-GCM key with HKDF-SHA256, and encrypts local JSON request/response bodies. The WebSocket uses a similar per-connection handshake and rejects plaintext application frames after setup. HTTP associated data binds ciphertext to direction, method, full path/query, and response status.
+
+This layer reduces casual exposure in browser network tooling. It is not a trusted-execution boundary: code running in the browser can observe plaintext before encryption or after decryption. The fixed handshake key is obfuscation, not a durable secret. See [ENCRYPTION_PROTOCOL.md](ENCRYPTION_PROTOCOL.md).
+
+## Task and terminal lifecycle
+
+- A user turn is correlated by access profile, logical MCP session, conversation scope, task ID, and turn ID.
+- `agent_user_message` opens/correlates the turn; progress, plan questions, tools, sub-agents, and terminal activity append timeline events.
+- Approval mode can pause a conversation or individual action for a local decision.
+- Persistent PTY sessions expose sequence-based replay, resize, signals, input, resource metadata, and explicit close operations.
+- Active operations register cancellation handles so a user can stop a tool, turn, task, or terminal.
+- `agent_turn_complete` finalizes a turn after active work ends. A watchdog reconciles stale turns when the remote client omits finalization.
+- Sub-agent records connect parent and child tasks. Host sampling is preferred; the optional browser extension can provide a bounded fallback when configured.
+
+## Persistence
+
+SQLite is the source of truth for:
+
+- stable local device identity;
+- settings and schema version;
+- MCP access profiles, secret hashes, tool catalog, presets, and allowlists;
+- tasks, logical sessions, turn bindings, approvals, and execution modes;
+- terminal metadata and chunked output;
+- timeline events and artifacts;
+- workspace projects;
+- ChatGPT bridge requests, conversation bindings, and message queue;
+- sub-agent and fallback state;
+- user-managed tunnel origins and public plugin-token hashes.
+
+Migrations in `crates/chatcmd-storage/migrations/` are append-only once released. SQLite WAL supports concurrent readers and a serialized event writer batches persistent events. Cleanup settings can remove generated task data while retaining access profiles, workspace projects, and system configuration.
+
+## Frontend
+
+The React application uses:
+
+- React Router for dashboard, tasks, sessions, access profiles, skills, and settings;
+- an encrypted fetch wrapper for management API calls;
+- an encrypted WebSocket provider for live events;
+- xterm.js for interactive terminals;
+- sanitized Markdown and Prism-based code rendering for task output;
+- browser-local preferences for presentation choices, backed by server settings where appropriate.
+
+Vite serves the development UI on port `5173` and proxies `/api` and `/ws` to port `8080`. Production builds can be served from `web/dist` or embedded into the Rust binary through the `embedded-web` feature.
+
+## ChatGPT extension
+
+The extension is optional and separate from MCP transport. It has permissions for tabs, storage, scripting, `chatgpt.com`, and loopback ChatCMD origins. It does not request cookie access.
+
+It drives the visible ChatGPT DOM, tracks conversation/tab bindings, returns assistant output to ChatCMD, and can render local approval controls. Local callback origin validation only accepts HTTP `localhost` or `127.0.0.1`. Because the integration depends on third-party page structure, selector changes are an expected maintenance cost.
+
+## Trust boundaries
+
+| Boundary | Primary controls | Important limitation |
+| --- | --- | --- |
+| AI client → MCP | URL token, hashed lookup, enabled profile, tool allowlist, schema validation, origin/host policy | Anyone with the full URL has the profile's authority. |
+| Runtime → filesystem/process | Canonical roots, structured arguments, policy decisions, approvals, limits, cancellation | Broadly configured roots or allow-all mode intentionally grant broad local power. |
+| Browser → local API | Caller marker, loopback expectation, encrypted bodies, session reset | A compromised local browser or OS account can inspect plaintext. |
+| Internet → public tunnel | Operator's HTTPS, access policy, firewall, and token secrecy | ChatCMD does not operate or secure the user's tunnel provider. |
+| Extension → ChatGPT | Restricted host permissions, no cookie permission, explicit DOM bridge | Other extensions or page changes can interfere with the same tab. |
+| Persistent storage | Local SQLite, profile-secret hashing, bounded event storage, cleanup | Public plugin tokens and application data are readable by the OS account and local administrators. |
+
+Security-sensitive changes should be reviewed against [SECURITY.md](../SECURITY.md) and tested across authentication, authorization, path handling, cancellation, persistence, and browser boundaries.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,165 @@
+# Development guide
+
+## Prerequisites
+
+- Rust 1.85 or newer with `rustfmt` and Clippy.
+- Node.js 20.19 or newer, or 22.12 or newer, and npm.
+- Git.
+- Windows: MSVC Build Tools and PowerShell.
+- macOS: Xcode Command Line Tools.
+- Linux: a compiler toolchain; `zenity` is used by the native folder picker when available.
+
+Install Rust components:
+
+```bash
+rustup component add rustfmt clippy
+```
+
+## Checkout and bootstrap
+
+```bash
+git clone https://github.com/int04/ChatCmdClient.git
+cd ChatCmdClient
+git switch dev
+
+cd web
+npm ci
+npm run build
+cd ..
+cargo check --workspace --all-targets
+```
+
+No `.env` file or hosted account is required. Avoid committing machine-specific environment configuration.
+
+## Run locally
+
+### Production-like local mode
+
+```bash
+cd web
+npm run build
+cd ..
+cargo run
+```
+
+Open <http://127.0.0.1:8080>.
+
+### Frontend hot reload
+
+Run the processes in separate terminals:
+
+```bash
+# Repository root
+cargo run
+```
+
+```bash
+cd web
+npm run dev
+```
+
+Open <http://127.0.0.1:5173>. The Vite server proxies API and WebSocket traffic to the Rust listener.
+
+Use `CHATCMD_DB_PATH` and `CHATCMD_LOG_PATH` to isolate manual-test data from a normal installation:
+
+```powershell
+$env:CHATCMD_DB_PATH = "$PWD/.smoke/chatcmd.db"
+$env:CHATCMD_LOG_PATH = "$PWD/.smoke/chatcmd.log"
+cargo run
+```
+
+The `.smoke/` directory is ignored by Git.
+
+## Test and quality commands
+
+### Rust workspace
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --all-targets
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Run a narrower Rust suite while iterating:
+
+```bash
+cargo test -p chatcmd-core
+cargo test -p chatcmd-storage
+cargo test -p chatcmd-runtime
+cargo test -p chatcmd-mcp
+```
+
+### React UI
+
+```bash
+cd web
+npm ci
+npm run lint
+npm test -- --run
+npm run build
+```
+
+During active development, `npm test` runs Vitest in watch mode.
+
+### Browser extension
+
+```bash
+cd chatgpt-extension
+node --test content-chatgpt.test.cjs
+```
+
+After changing DOM selectors, also load the unpacked extension in a dedicated browser profile and manually verify start, continue, stop, model selection, approvals, queue behavior, and final-response capture.
+
+## Change map
+
+| Change | Files normally involved |
+| --- | --- |
+| MCP tool/schema | `crates/chatcmd-mcp/src/lib.rs`, `tool_catalog.rs`, runtime dispatch, tests, `docs/mcp_method.md` |
+| Filesystem behavior | `crates/chatcmd-runtime/src/filesystem*.rs`, runtime host dispatch, MCP schema, tests |
+| Task lifecycle | `src/runtime_host/`, `src/api/task_*.rs`, storage repository/migration, task UI/tests |
+| Local API | `src/api/`, `web/src/api.ts`, `web/src/types.ts`, UI caller, tests |
+| Real-time event | `src/websocket/`, event publisher, `web/src/realtime.ts`, timeline mapping/tests |
+| Persistent data | new numbered SQL migration, repository methods, migration/storage tests |
+| Skill management | runtime skill service, `src/api/skills.rs`, `web/src/pages/SkillsPage.tsx` |
+| ChatGPT DOM bridge | `chatgpt-extension/content-chatgpt*.js`, background scripts, extension tests |
+| User-facing copy | React component plus both English and Vietnamese entries in `web/src/i18n.ts` |
+
+## Adding or changing an MCP tool
+
+1. Define typed arguments and the tool handler in `chatcmd-mcp`.
+2. Add or update the runtime trait and dispatch implementation.
+3. Enforce authenticated identity and ignore caller-provided authority fields.
+4. Add policy, approval, size, timeout, cancellation, and path bounds appropriate to the operation.
+5. Classify mutating/destructive capability so presets and the UI remain correct.
+6. Update catalog/schema consistency tests.
+7. Update `docs/mcp_method.md` and any affected examples.
+8. Verify the actual router catalog, not only a hand-maintained list.
+
+## Database migrations
+
+- Add a new, monotonically numbered SQL file under `crates/chatcmd-storage/migrations/`.
+- Never rewrite an already released migration.
+- Keep startup migration idempotence and newer-schema rejection intact.
+- Add storage tests for a fresh database and an upgrade path.
+- Consider restart recovery, concurrent readers, event ordering, cleanup, and legacy import behavior.
+
+## API and frontend conventions
+
+- Management routes live under `/api/local` and use RFC 7807-style problem details for errors.
+- Add frontend calls through `web/src/api.ts`; do not bypass the encrypted API wrapper for JSON management data.
+- Decide explicitly how binary, streamed, image, multipart, or SSE responses interact with API encryption.
+- Keep real-time payloads bounded and avoid sending entire large files or terminal histories.
+- Sanitize rendered Markdown and preserve keyboard/accessibility behavior.
+
+## Git and pull requests
+
+Preserve unrelated local changes. Use a focused branch and target `dev` unless a maintainer says otherwise. Before opening a pull request, review:
+
+```bash
+git status --short
+git diff --check
+git diff --stat
+```
+
+Follow [CONTRIBUTING.md](../CONTRIBUTING.md) and complete the pull-request template.

--- a/docs/OPEN_SOURCE_CHECKLIST.md
+++ b/docs/OPEN_SOURCE_CHECKLIST.md
@@ -1,0 +1,62 @@
+# Open-source publication checklist
+
+Use this checklist before changing the GitHub repository visibility to public. Repository files alone cannot configure every required GitHub or third-party setting.
+
+## Legal and ownership
+
+- [ ] Confirm the copyright line in `LICENSE` names the correct rights holder.
+- [ ] Confirm every contributor and employer has the right to publish their contributions.
+- [ ] Review bundled images, sounds, fonts, icons, and copied code for redistribution rights.
+- [ ] Review third-party dependency licenses and notices for compatibility with MIT distribution.
+- [ ] Confirm the project name, logo, and domain can be used publicly; document any trademark policy if needed.
+- [ ] Obtain legal review if the project is published by a company or includes third-party proprietary work.
+
+## Secrets and private data
+
+- [ ] Scan the **entire Git history**, not only the current tree, with a maintained secret scanner.
+- [ ] Rotate every credential that ever appeared in a commit, release archive, log, issue, or build output.
+- [ ] Check for MCP URLs, public plugin tokens, cookies, API keys, tunnel credentials, signing keys, notarization credentials, database files, logs, conversations, user names, emails, and absolute personal paths.
+- [ ] Review deleted backend, authentication, payment, and tunnel code still present in Git history.
+- [ ] Remove private artifacts from existing tags, branches, pull requests, and release assets.
+- [ ] If history must be rewritten, coordinate it before public release and rotate affected credentials even after removal.
+
+## Repository settings
+
+- [ ] Set the GitHub description, website, topics, and social preview image.
+- [ ] Confirm GitHub detects the MIT license.
+- [ ] Enable private vulnerability reporting and security advisories.
+- [ ] Enable dependency graph, Dependabot alerts, and secret scanning where available.
+- [ ] Create the `bug`, `enhancement`, and `documentation` labels used by issue templates.
+- [ ] Decide whether to enable Discussions for support and design proposals.
+- [ ] Configure branch protection for `main` and `dev`, including required review and status checks.
+- [ ] Restrict force pushes and branch deletion for protected branches.
+- [ ] Configure release/tag permissions and require two-factor authentication for maintainers.
+- [ ] Review Actions permissions before enabling workflows from forks.
+
+## Engineering readiness
+
+- [ ] Make `cargo fmt --check`, Cargo check/test/Clippy, frontend lint/test/build, and extension tests pass from a clean checkout.
+- [ ] Add CI only after the baseline is green, then require it on protected branches.
+- [ ] Test source setup exactly as documented on supported platforms.
+- [ ] Test Windows and macOS release archives on clean machines.
+- [ ] Verify database migrations and restart recovery from the latest supported release.
+- [ ] Verify public tunnel behavior with HTTPS and a disposable, least-privilege profile.
+- [ ] Verify the extension in a dedicated browser profile and document the supported browsers.
+- [ ] Generate software-bill-of-materials or dependency-license reports if required by the distributor.
+
+## Documentation and community
+
+- [ ] Replace the blank screenshot sections in `README.md` with redacted current images.
+- [ ] Verify all relative links and public URLs after the repository becomes public.
+- [ ] Review `README.md`, `SECURITY.md`, `SUPPORT.md`, `CONTRIBUTING.md`, `GOVERNANCE.md`, and the Code of Conduct.
+- [ ] Confirm the private security and conduct-reporting channels actually work.
+- [ ] Publish a first changelog section, signed/annotated tag, release notes, checksums, and supported-platform statement.
+- [ ] Triage initial issues and clearly label good first issues where appropriate.
+
+## Final publication review
+
+- [ ] Clone the future-public repository into a clean directory using an unauthenticated session.
+- [ ] Build and test from that clone without relying on ignored files or global private configuration.
+- [ ] Inspect the rendered README, Mermaid diagram, badges, issue templates, and license page.
+- [ ] Download and verify every release artifact and checksum as an anonymous user.
+- [ ] Announce the supported version and avoid promising warranties or service levels beyond `SUPPORT.md`.

--- a/docs/PLUGIN_SETUP.md
+++ b/docs/PLUGIN_SETUP.md
@@ -1,0 +1,132 @@
+# Plugin and ChatGPT setup
+
+This guide explains how to create a ChatCMD MCP access profile, connect a local client, expose it through an operator-managed public address, connect it to ChatGPT's plugin interface, and install the optional ChatGPT browser extension.
+
+The ChatGPT interface and terminology can change. The steps below reflect the current source and the referenced ChatCMD v1.0 walkthroughs:
+
+- [Create a Plugin connection](https://chatcmd.net/docs/v1.0/vi/tao-agent-dau-tien)
+- [Connect to ChatGPT](https://chatcmd.net/docs/v1.0/vi/ket-noi-voi-chatgpt)
+- [Install the extension](https://chatcmd.net/docs/v1.0/vi/them-extension)
+
+## 1. Start ChatCMD
+
+Build and run the application, then open <http://127.0.0.1:8080>. See the root [README](../README.md) for source and release builds.
+
+Keep the management page available while testing. With the default settings, a new conversation or sensitive operation may wait for your approval.
+
+## 2. Create an access profile
+
+1. Open **Plugin list**.
+2. Select **Create new Plugin connection**.
+3. Enter a short, recognizable name. Using the same name in ChatCMD and the AI client makes `@plugin-name` selection easier to understand.
+4. Choose a preset or individual tools. Grant only what the use case needs. If you temporarily select all tools for diagnosis, reduce the allowlist afterward.
+5. Leave **Allow connections** enabled and save.
+
+Use separate profiles for unrelated clients or trust levels. Disabling a profile blocks its normal MCP access without deleting its history or configuration.
+
+## 3. Connect a local MCP client
+
+Open the profile's `•••` menu and select **Create new access code**. Copy the endpoint while it is visible:
+
+```text
+http://127.0.0.1:8080/mcp/<token>
+```
+
+Configure it as a Streamable HTTP MCP server. The URL itself is the credential; do not add it to source control, screenshots, public logs, issue reports, or shared shell history. No `Authorization` header is required.
+
+## 4. Prepare a public address for a web-hosted AI
+
+A web-hosted AI cannot normally reach `127.0.0.1` on your computer. Create an HTTPS reverse proxy or tunnel that you control and point it to:
+
+```text
+http://127.0.0.1:8080
+```
+
+Suitable approaches include a named Cloudflare Tunnel, another authenticated tunnel provider, a private network gateway, or a carefully firewalled reverse proxy. The open-source client does **not** include a managed ChatCMD tunnel service.
+
+Security requirements:
+
+- prefer a stable HTTPS hostname;
+- configure tunnel access policy and firewall rules where compatible with the AI client;
+- do not expose a development machine broadly without understanding the risk;
+- never put the MCP token in a query string;
+- remember that the public origin reaches the same HTTP listener as the UI and health endpoints;
+- rotate or disable the access profile immediately if its URL leaks.
+
+In **Plugin list**, expand **Custom Tunnel / private domain**, select **Add new domain / Tunnel**, enter only the origin (for example `https://mcp.example.com`), and save. ChatCMD validates the address by requesting:
+
+```text
+https://mcp.example.com/api/ping
+```
+
+The address is saved only when it returns the expected ChatCMD response. You can test it again from the list.
+
+## 5. Copy a public connection link
+
+1. Select **Copy connection link** on the desired access profile.
+2. Choose the verified public address.
+3. Select **Test connection** if needed.
+4. Select **Copy**. The full token remains hidden on screen and is placed directly on the clipboard.
+
+Treat the copied value as a password. ChatCMD stores public plugin-link tokens in the local SQLite database in recoverable plaintext so the same link can be copied again; protect the operating-system account, disk, backups, and database file accordingly.
+
+## 6. Add the plugin in ChatGPT
+
+The exact labels depend on the ChatGPT plan and current UI. If your account exposes custom plugins/MCP connections:
+
+1. Open the ChatGPT user menu and **Settings**.
+2. Under **Security and sign-in**, enable **Developer mode**.
+3. Return to ChatGPT, open **Plugins**, and select the add (`+`) action.
+4. Use the same name as the ChatCMD access profile.
+5. Paste the public tokenized URL into **Connection**.
+6. Select **No authentication** because the secret is already embedded in the path.
+7. Acknowledge the developer warning, create the plugin, and select **Connect**.
+8. Review the plugin's permissions. Only choose an always-allow option if that matches your risk tolerance and ChatCMD's tool allowlist is appropriately narrow.
+9. Reload ChatGPT so the new plugin is discovered.
+
+Do not repeatedly create failing plugins. If ChatGPT rate-limits plugin creation, stop and retry later after fixing the endpoint.
+
+## 7. Test a conversation
+
+1. In a new ChatGPT conversation, type `@` and select the configured plugin. Reload the page if it does not appear.
+2. On the first request, include or select a working project folder so the runtime has a clear workspace.
+3. Watch the ChatCMD management UI for the new task and approve the conversation when prompted.
+4. Review every requested local action. You can allow once, allow similar actions for that scope, or reject it.
+5. Confirm that progress, tool activity, file changes, terminal output, and the final response appear in the task timeline.
+
+Once the plugin is active in a conversation, ChatGPT may not require an explicit `@name` mention for every follow-up.
+
+## 8. Install the optional ChatGPT extension
+
+The unpacked extension improves the ChatGPT web workflow and can surface ChatCMD approvals in the ChatGPT page. It is not required for normal MCP clients.
+
+1. Locate `chatgpt-extension/` in the source checkout or release archive.
+2. Open your Chromium browser's extensions page, for example:
+
+   ```text
+   chrome://extensions/
+   edge://extensions/
+   brave://extensions/
+   ```
+
+3. Enable **Developer mode**.
+4. Select **Load unpacked** and choose the `chatgpt-extension` directory.
+5. Confirm that **ChatCMD ChatGPT Bridge** is enabled.
+6. Sign in to <https://chatgpt.com> in the same browser profile.
+7. Reload both ChatGPT and the local ChatCMD page.
+
+The extension requests `tabs`, `storage`, and `scripting` permissions plus access to `chatgpt.com` and loopback ChatCMD origins. It does not request cookie permission. Read [chatgpt-extension/README.md](../chatgpt-extension/README.md) before enabling it.
+
+After updating ChatCMD, reload the unpacked extension from the browser extensions page. If files were replaced manually and reload is insufficient, remove the extension and load the directory again.
+
+## 9. Verify and revoke access
+
+- Test only with a disposable repository or folder first.
+- Confirm destructive tools are absent unless explicitly required.
+- Confirm approval prompts appear in the expected UI.
+- Inspect **Settings → Data & logs** for local and extension diagnostics.
+- Disable the profile to suspend access.
+- Use **Create new access code** when a local endpoint must be replaced.
+- Delete a public address when it is no longer used, and separately disable or remove it at the tunnel provider.
+
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) when the connection, extension, or approval flow does not work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# ChatCMD documentation
+
+This directory contains technical and operational documentation for the open-source ChatCMD client.
+
+## Users and operators
+
+- [Plugin and ChatGPT setup](PLUGIN_SETUP.md)
+- [Troubleshooting](TROUBLESHOOTING.md)
+- [MCP method reference](mcp_method.md)
+- [Diagnostic logs](logs.md)
+- [Encryption protocol](ENCRYPTION_PROTOCOL.md)
+
+## Contributors and maintainers
+
+- [Architecture](ARCHITECTURE.md)
+- [Development guide](DEVELOPMENT.md)
+- [Release guide](RELEASING.md)
+- [Open-source publication checklist](OPEN_SOURCE_CHECKLIST.md)
+- [Engineering plans](../plan/00-README.md)
+
+Community policies are stored at the repository root: [Contributing](../CONTRIBUTING.md), [Security](../SECURITY.md), [Support](../SUPPORT.md), [Governance](../GOVERNANCE.md), [Roadmap](../ROADMAP.md), and [Code of Conduct](../CODE_OF_CONDUCT.md).
+
+The website documentation at [chatcmd.net/docs](https://chatcmd.net/docs) may include product screenshots and version-specific walkthroughs. Source-controlled documentation is authoritative for the behavior of the checked-out revision.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,101 @@
+# Release guide
+
+This guide is for maintainers preparing source and desktop releases.
+
+## 1. Prepare the release
+
+1. Start from reviewed stable history and ensure `dev` contains the intended changes.
+2. Decide the semantic version.
+3. Update versions consistently in:
+   - root `Cargo.toml`;
+   - each workspace crate `Cargo.toml`;
+   - `web/package.json` and `web/package-lock.json`;
+   - `chatgpt-extension/manifest.json` when the extension changed.
+4. Update [CHANGELOG.md](../CHANGELOG.md): move relevant entries from **Unreleased** into a dated version section.
+5. Verify user, plugin, security, migration, and protocol documentation.
+6. Confirm no secret, local database, log, source map, personal path, or unsigned private credential is staged.
+
+`CHATCMD_BUILD_VERSION` overrides the displayed/package version without changing source metadata. Public releases should still keep source manifests aligned.
+
+## 2. Run quality gates
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --all-targets
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+
+cd web
+npm ci
+npm run lint
+npm test -- --run
+npm run build
+
+cd ../chatgpt-extension
+node --test content-chatgpt.test.cjs
+```
+
+Inspect dependency and license changes. Perform manual smoke tests for access-profile creation, endpoint rotation, MCP connection, permissions, approvals, terminal lifecycle, task completion, data persistence/restart, and extension behavior.
+
+## 3. Build Windows packages
+
+Run from a Windows developer environment with Rustup and both MSVC targets available:
+
+```powershell
+.\scripts\build-windows.ps1 -Version 0.1.0
+```
+
+The script:
+
+- installs/checks `x86_64-pc-windows-msvc` and `i686-pc-windows-msvc`;
+- builds and obfuscates the frontend without source maps;
+- builds `embedded-web` release binaries;
+- copies and obfuscates the unpacked extension;
+- creates 64-bit and 32-bit directories and ZIP archives under `release/`.
+
+Verify both architectures on clean supported systems. Confirm `ChatCMD.exe` metadata and icon, browser launch, tray exit, database creation, and extension contents.
+
+## 4. Build macOS packages
+
+Run on macOS with Rustup, Xcode command-line tools, and the required signing identity:
+
+```bash
+CHATCMD_BUILD_VERSION=0.1.0 \
+MACOS_SIGN_IDENTITY="Developer ID Application: Example (TEAMID)" \
+MACOS_NOTARY_PROFILE="ChatCMDNotary" \
+./scripts/build-macos.sh
+```
+
+If no signing identity is found, the script can produce an ad-hoc signed development package. Do not present an ad-hoc package as a notarized public release.
+
+The script builds Apple Silicon and Intel targets, embeds the frontend, creates app bundles and icons, includes the extension, signs the app, optionally notarizes/staples it, and creates ZIP archives under `release/`.
+
+Test both architectures or document any untested artifact. Verify Gatekeeper behavior, tray lifecycle, browser launch, database location, and extension loading.
+
+## 5. Inspect artifacts
+
+- Ensure ZIP names and displayed versions match the release.
+- Confirm no `.map` files exist.
+- Confirm source-only files, databases, logs, and signing material are absent.
+- Scan archives with the available platform security tools.
+- Generate and publish SHA-256 checksums.
+- Extract each archive into a clean directory and smoke-test the extracted copy.
+- Confirm the bundled extension manifest version and source match the release notes.
+
+## 6. Tag and publish
+
+1. Merge the reviewed release state into `main`.
+2. Create a signed or annotated tag such as `v0.1.0` from the release commit.
+3. Push the branch and tag.
+4. Create a GitHub release using the matching changelog section.
+5. Attach platform archives and checksums.
+6. Clearly label prereleases, unsigned artifacts, unsupported platforms, migrations, breaking changes, and known limitations.
+7. Keep source archives available under the MIT license.
+
+## 7. After release
+
+- Verify download links and checksums from another machine.
+- Confirm the version displayed by the app.
+- Restore an **Unreleased** section in the changelog if needed.
+- Announce security-relevant changes through the coordinated disclosure agreed with reporters.
+- Merge urgent release-only fixes back into `dev` so branches do not drift.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,143 @@
+# Troubleshooting
+
+Start with the smallest reproducible configuration: loopback binding, default port, one access profile, a narrow tool allowlist, and no public tunnel.
+
+## The management page does not open
+
+1. Confirm the Rust process is still running.
+2. Open <http://127.0.0.1:8080/api/health> and <http://127.0.0.1:8080/api/info>.
+3. Check whether another process owns port `8080`.
+4. If `CHATCMD_PORT` is set, open that port instead.
+5. For a non-embedded build, build `web/dist` or use the Vite development server.
+
+```bash
+cd web
+npm ci
+npm run build
+cd ..
+cargo run
+```
+
+If the API works but frontend assets do not, verify `web/dist/index.html` or set `CHATCMD_WEB_DIST` to the correct build directory.
+
+## Port 8080 is already in use
+
+Set another valid port before starting:
+
+```powershell
+$env:CHATCMD_PORT = "8081"
+cargo run
+```
+
+Update the extension/local client configuration and any reverse proxy to match. Vite's checked-in proxy targets port `8080`; adjust `web/vite.config.ts` for a different backend during frontend development.
+
+## The MCP client reports unauthorized
+
+- Verify the entire `/mcp/<token>` URL was copied with no spaces or punctuation.
+- Do not move the token into `?token=`, `?access_token=`, or `?bearer_token=`; query credentials are rejected.
+- Confirm the access profile is enabled.
+- If a new access code was created, replace the old local endpoint in the client.
+- Create a fresh access code if the URL may have been truncated or exposed.
+
+## The MCP client reports an origin or host error
+
+Browser origins are limited to the configured local `localhost`/`127.0.0.1` origin. Native clients may omit `Origin` only while ChatCMD is bound to loopback. Binding directly to a non-loopback address enables stricter host validation and denies origin-less clients.
+
+Prefer leaving `CHATCMD_BIND=127.0.0.1` and using a well-configured tunnel/reverse proxy on the same machine. Inspect proxy host/header behavior before weakening a boundary.
+
+## A public address cannot be saved or tested
+
+ChatCMD requests `<origin>/api/ping` and expects a successful JSON response with `pong: true` and `service: ChatCMD`.
+
+- Confirm the tunnel targets the current ChatCMD port.
+- Enter only the origin—no MCP path, token, query, fragment, username, or password.
+- Verify DNS and TLS from the ChatCMD machine.
+- Check tunnel access rules; an interactive login page will fail the probe.
+- Check that the tunnel provider did not rewrite `/api/ping`.
+- Do not add `localhost` or `127.0.0.1` as a public address.
+
+## ChatGPT cannot create or discover the plugin
+
+- Confirm Developer mode is available and enabled for the current account/workspace.
+- Use the verified public tokenized URL, not `localhost`.
+- Select **No authentication**; the URL path is already the bearer credential.
+- Reload ChatGPT after creating the plugin.
+- Type `@` and search for the exact configured name.
+- If plugin creation was attempted repeatedly, wait before trying again.
+- Check for account, workspace, plan, or administrator restrictions in ChatGPT.
+
+## The browser extension is not detected
+
+1. Open the browser's extensions page.
+2. Confirm Developer mode and **ChatCMD ChatGPT Bridge** are enabled.
+3. Reload the unpacked extension after every source update.
+4. Reload both `chatgpt.com` and the local ChatCMD page.
+5. Use the same browser profile for the extension and the signed-in ChatGPT tab.
+6. Open **Settings → Data & logs → Extension logs**.
+
+The bridge accepts local callbacks only from HTTP `localhost` or `127.0.0.1`. It will not use a remote ChatCMD management origin.
+
+## ChatGPT sending, stopping, or response capture broke
+
+The extension is DOM-based and third-party UI changes can invalidate selectors. Run:
+
+```bash
+cd chatgpt-extension
+node --test content-chatgpt.test.cjs
+```
+
+Then inspect the browser extension service worker console and extension logs. Record the ChatGPT UI variant and visible model label in a bug report, but redact conversations and credentials.
+
+## A new conversation is waiting
+
+The default configuration requires approval for new ChatGPT conversations. Open the ChatCMD page and approve or reject the waiting conversation. With the extension enabled, the same approval may appear inside ChatGPT.
+
+If approvals are intentionally unnecessary on a trusted single-user machine, review **Settings → Execution → Approve new conversations**. Disabling it broadens automatic access.
+
+## A tool is waiting for approval
+
+Approval mode pauses sensitive operations. Review the exact tool and input, then choose:
+
+- allow this request;
+- allow similar requests in the supported scope;
+- reject.
+
+If no dialog is visible, reload the management page and check pending approvals, the task timeline, the encrypted WebSocket connection, and application logs.
+
+## A terminal is busy or input is locked
+
+Interactive input is disabled while an agent owns the terminal. Wait for the active operation, stop that activity from the task timeline, or close the session if interruption is acceptable. After an unexpected restart, stale sessions are marked interrupted and cannot be resumed as live processes.
+
+## The UI says “Request failed (200)”
+
+An HTTP handler may have succeeded while the browser failed to decrypt the response. Check:
+
+- `X-ChatCmd-Crypto: 1` on the response;
+- whether the Rust backend restarted and the browser performed one session reset/retry;
+- method, full `/api/local/...` path, query ordering, and status used as AES-GCM associated data;
+- proxy or middleware changes that modified the request URI/body;
+- browser console errors.
+
+See [ENCRYPTION_PROTOCOL.md](ENCRYPTION_PROTOCOL.md) for the full checklist.
+
+## The database cannot open or migrate
+
+- Verify the parent directory is writable.
+- Check free disk space and filesystem permissions.
+- Confirm `CHATCMD_DB_PATH` points to a file, not a directory.
+- Do not open the same database with incompatible application builds.
+- Back up the database before manual inspection or repair.
+
+ChatCMD rejects a database with a schema newer than the current binary rather than attempting a downgrade.
+
+## Where to find diagnostics
+
+- Dashboard: runtime, MCP, database, task, terminal, and approval status.
+- **Settings → Data & logs**: SQLite metrics, application logs, extension logs, retention, and cleanup.
+- Default application log: `logs/chatcmd.log`.
+- Override log path: `CHATCMD_LOG_PATH`.
+- Rust tracing: configure `RUST_LOG` before launch.
+
+Review logs before sharing them. Remove endpoint tokens, private paths, conversations, user data, and proprietary source content.
+
+If the problem remains, follow [SUPPORT.md](../SUPPORT.md) and use the appropriate issue template.

--- a/docs/mcp_method.md
+++ b/docs/mcp_method.md
@@ -7,7 +7,7 @@ Nguồn đối chiếu chính:
 - `crates/chatcmd-mcp/src/tool_catalog.rs` — danh sách method ổn định được expose.
 - `crates/chatcmd-mcp/src/lib.rs` — schema/description của từng method.
 
-> Tổng số hiện tại: **45 methods**.
+> Tổng số hiện tại: **46 methods**.
 
 ## Quy ước chung
 
@@ -137,6 +137,7 @@ Các Git method được thiết kế để tránh shell interpolation và truy�
 |---|---|---|
 | `agent_user_message` | `content` | **Bắt buộc là MCP call đầu tiên và chỉ gọi đúng một lần trong mỗi user turn.** Đồng bộ nguyên văn user message lên ChatCMD và thiết lập/correlate `taskId` + `turnId`. `content` phải đúng nguyên văn message hiện tại. Không dùng method này cho progress/reflection/finding sau tool result; các cập nhật đó phải dùng `agent_progress`. |
 | `agent_progress` | `message`, `suggestedTitle?` | **Rule phía AI cho mọi turn project không-trivial.** Ngay sau `agent_user_message` nên gửi progress tóm tắt yêu cầu + hành động kế tiếp. Sau các kết quả `fs_*` có ý nghĩa (đặc biệt `fs_find`, `fs_search`, `fs_read_text`, edit/write/delete), Git/process, `shell_read`/`shell_wait` còn pending, sub-agent wait chưa xong, hoặc failure/non-zero, AI nên gửi progress mô tả kết quả quan sát được và bước tiếp theo trước khi tiếp tục. Đây không phải runtime gate: server không reject tool chỉ vì thiếu progress; các thao tác low-level liên quan chặt có thể gom thành một checkpoint để tránh làm chậm tiến độ và tránh callback MCP không cần thiết. Không gửi private chain-of-thought. |
+| `agent_plan_question` | `question`, `options` | Tạm dừng plan để hỏi người dùng một câu hỏi có hai lựa chọn rõ ràng; câu trả lời được tiếp tục qua hàng đợi phê duyệt của ChatCMD. |
 | `agent_subagent_start` | `name`, `request` | Tạo và dispatch một child agent khi ChatGPT chủ động chia việc hoặc người dùng yêu cầu chia agent. Chỉ sử dụng model sampling do ChatGPT/MCP host cung cấp; nếu host không hỗ trợ sampling thì trả `samplingUnavailable`/`failed` và tuyệt đối không khởi chạy Codex hay executor local. |
 | `agent_subagent_wait` | `timeoutMs?` | Chờ các child agent của parent turn. Nếu `allFinished=false` thì tiếp tục gọi lại trước khi finalize. |
 | `agent_turn_complete` | `content`, `suggestedTitle?` | **Bắt buộc là MCP call cuối cùng.** Xác nhận turn đã hoàn tất và gửi đúng nội dung cuối cùng agent sẽ trả cho user. Chỉ được gọi đúng một lần sau khi mọi tool/sub-agent đã xong. |
@@ -192,9 +193,10 @@ Thứ tự ổn định hiện tại trong `TOOL_NAMES`:
 40. task_artifact_read
 41. agent_user_message
 42. agent_progress
-43. agent_subagent_start
-44. agent_subagent_wait
-45. agent_turn_complete
+43. agent_plan_question
+44. agent_subagent_start
+45. agent_subagent_wait
+46. agent_turn_complete
 ```
 
 ---

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "chat-cmd-client-web",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@vitejs/plugin-react": "latest",
         "@xterm/addon-fit": "^0.11.0",

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,8 @@
   "name": "chat-cmd-client-web",
   "private": true,
   "version": "0.1.0",
+  "license": "MIT",
+  "repository": "https://github.com/int04/ChatCmdClient",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- add the MIT license and license metadata for every Rust crate and the web package
- replace the minimal README with an international English overview, complete feature inventory, setup, configuration, build, security, and screenshot placeholders
- add contribution, conduct, security, support, governance, roadmap, changelog, and contributor documentation
- add architecture, development, plugin/ChatGPT setup, troubleshooting, release, and open-source publication guides
- add GitHub issue and pull-request templates
- correct the main-branch MCP reference to include agent_plan_question and all 46 methods

## Validation

- cargo check --workspace --all-targets: pass
- cargo test --workspace: pass
- npm run build: pass
- package/manifest JSON parse: pass
- relative Markdown links: pass
- git diff --check: pass

## Existing baseline failures

- cargo fmt --check: four existing Rust files need formatting on main
- cargo clippy --workspace --all-targets -- -D warnings: existing too_many_arguments warning in filesystem_search.rs
- npm run lint: existing 8 errors and 8 warnings
- npm test -- --run: existing App.test.tsx failures (41/48 tests pass)
- extension test: two existing failures (17/19 tests pass)

No application source files were changed by this pull request.