### PR TITLE
Restore main release workflow and harden Windows CI builds

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -1,6 +1,6 @@
-name: Build desktop DEV release
+name: Build desktop release
 
-run-name: Build desktop DEV release from ${{ github.ref_name }}
+run-name: Build desktop release from ${{ github.ref_name }}
 
 on:
   workflow_dispatch:
@@ -9,36 +9,35 @@ permissions:
   contents: read
 
 concurrency:
-  group: desktop-dev-release
+  group: desktop-release
   cancel-in-progress: false
 
 jobs:
   prepare:
-    name: Prepare DEV release version
+    name: Prepare release version
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - name: Require dev branch
-        if: github.ref != 'refs/heads/dev'
+      - name: Require main branch
+        if: github.ref != 'refs/heads/main'
         shell: bash
         run: |
-          echo "Desktop DEV releases must be built from the dev branch." >&2
+          echo "Desktop releases must be built from the main branch." >&2
           exit 1
 
-      - name: Generate DEV release version
+      - name: Generate release version
         id: version
         shell: bash
         run: |
-          base_version="$(TZ=Asia/Ho_Chi_Minh date '+%y.%m.%d.%H%M')"
+          version="$(TZ=Asia/Ho_Chi_Minh date '+%y.%m.%d.%H%M')"
           release_date="$(TZ=Asia/Ho_Chi_Minh date '+%y.%m.%d')"
-          version="${base_version}-DEV"
-          tag="v.${release_date}-DEV"
+          tag="v.${release_date}"
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "Building ChatCMD ${version} for DEV release ${tag}"
+          echo "Building ChatCMD ${version} for release ${tag}"
 
   windows:
     name: Build Windows x64 and x86
@@ -67,20 +66,20 @@ jobs:
           RUSTFLAGS: -C target-feature=+crt-static
         run: ./scripts/build-windows.ps1 -Version '${{ needs.prepare.outputs.version }}'
 
-      - name: Give DEV release assets stable names
+      - name: Give release assets stable names
         shell: pwsh
         run: |
           $version = '${{ needs.prepare.outputs.version }}'
-          Move-Item -LiteralPath "release/${version}_64.zip" -Destination 'release/ChatCMD-windows-x64-DEV.zip'
-          Move-Item -LiteralPath "release/${version}_32.zip" -Destination 'release/ChatCMD-windows-x86-DEV.zip'
+          Move-Item -LiteralPath "release/${version}_64.zip" -Destination 'release/ChatCMD-windows-x64.zip'
+          Move-Item -LiteralPath "release/${version}_32.zip" -Destination 'release/ChatCMD-windows-x86.zip'
 
       - name: Upload Windows packages
         uses: actions/upload-artifact@v7
         with:
-          name: windows-dev-packages
+          name: windows-packages
           path: |
-            release/ChatCMD-windows-x64-DEV.zip
-            release/ChatCMD-windows-x86-DEV.zip
+            release/ChatCMD-windows-x64.zip
+            release/ChatCMD-windows-x86.zip
           if-no-files-found: error
           retention-days: 7
 
@@ -105,26 +104,26 @@ jobs:
           CHATCMD_BUILD_VERSION: ${{ needs.prepare.outputs.version }}
         run: bash ./scripts/build-macos.sh
 
-      - name: Give DEV release assets stable names
+      - name: Give release assets stable names
         shell: bash
         env:
           CHATCMD_BUILD_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          mv "release/${CHATCMD_BUILD_VERSION}_intel.zip" "release/ChatCMD-macos-intel-DEV.zip"
-          mv "release/${CHATCMD_BUILD_VERSION}_silicon.zip" "release/ChatCMD-macos-apple-silicon-DEV.zip"
+          mv "release/${CHATCMD_BUILD_VERSION}_intel.zip" "release/ChatCMD-macos-intel.zip"
+          mv "release/${CHATCMD_BUILD_VERSION}_silicon.zip" "release/ChatCMD-macos-apple-silicon.zip"
 
       - name: Upload macOS packages
         uses: actions/upload-artifact@v7
         with:
-          name: macos-dev-packages
+          name: macos-packages
           path: |
-            release/ChatCMD-macos-intel-DEV.zip
-            release/ChatCMD-macos-apple-silicon-DEV.zip
+            release/ChatCMD-macos-intel.zip
+            release/ChatCMD-macos-apple-silicon.zip
           if-no-files-found: error
           retention-days: 7
 
   release:
-    name: Publish DEV release
+    name: Publish latest release
     needs:
       - prepare
       - windows
@@ -136,13 +135,13 @@ jobs:
       - name: Download Windows packages
         uses: actions/download-artifact@v8
         with:
-          name: windows-dev-packages
+          name: windows-packages
           path: dist
 
       - name: Download macOS packages
         uses: actions/download-artifact@v8
         with:
-          name: macos-dev-packages
+          name: macos-packages
           path: dist
 
       - name: Generate SHA-256 checksums
@@ -150,7 +149,7 @@ jobs:
         working-directory: dist
         run: sha256sum *.zip > SHA256SUMS.txt
 
-      - name: Publish GitHub DEV release
+      - name: Publish GitHub release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -158,10 +157,10 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           release_title="ChatCMD ${RELEASE_TAG#v.}"
-          release_notes="DEV build automatically built from dev. Build version: ${RELEASE_VERSION}. See SHA256SUMS.txt to verify downloads. The macOS packages are ad-hoc signed and are not notarized."
+          release_notes="Automatically built from main. Build version: ${RELEASE_VERSION}. See SHA256SUMS.txt to verify downloads. The macOS packages are ad-hoc signed and are not notarized."
 
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "DEV release ${RELEASE_TAG} already exists; replacing assets."
+            echo "Release ${RELEASE_TAG} already exists; replacing assets."
             gh release upload "$RELEASE_TAG" dist/*.zip dist/SHA256SUMS.txt \
               --repo "$GITHUB_REPOSITORY" \
               --clobber
@@ -169,13 +168,13 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --title "$release_title" \
               --notes "$release_notes" \
-              --prerelease
+              --latest
           else
-            echo "Creating DEV release ${RELEASE_TAG}."
+            echo "Creating release ${RELEASE_TAG}."
             gh release create "$RELEASE_TAG" dist/*.zip dist/SHA256SUMS.txt \
               --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" \
               --title "$release_title" \
               --notes "$release_notes" \
-              --prerelease
+              --latest
           fi


### PR DESCRIPTION
Restores the production desktop release workflow for main and hardens Windows CI artifacts by pinning Windows Server 2022, pinning Rust 1.98.0 to match local builds, and statically linking the MSVC CRT. No Rust source code changes.