### PR TITLE
fix: make packaged macOS workspace stable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,10 +164,7 @@ async fn run_server(ready: Option<std::sync::mpsc::Sender<()>>) -> Result<()> {
             .context("start filesystem journal persistence")?,
     );
 
-    let root = std::env::current_dir()
-        .context("resolve current workspace")?
-        .canonicalize()
-        .context("canonicalize workspace")?;
+    let root = resolve_workspace_root()?;
     let policy = ExecutionPolicy {
         default: PolicyDecision::Allow,
         per_agent_tool: BTreeMap::new(),
@@ -435,6 +432,28 @@ fn trace_route(path: &str) -> &str {
 
 fn user_home() -> Option<PathBuf> {
     std::env::var_os(if cfg!(windows) { "USERPROFILE" } else { "HOME" }).map(PathBuf::from)
+}
+
+fn resolve_workspace_root() -> Result<PathBuf> {
+    #[cfg(all(not(debug_assertions), feature = "embedded-web"))]
+    if let Some(home) = user_home() {
+        let workspace = if cfg!(target_os = "macos") {
+            home.join("Library/Application Support/ChatCmdClient/workspace")
+        } else if cfg!(target_os = "windows") {
+            home.join("AppData/Roaming/ChatCmdClient/workspace")
+        } else {
+            home.join(".local/share/ChatCmdClient/workspace")
+        };
+        std::fs::create_dir_all(&workspace).context("create packaged workspace")?;
+        return workspace
+            .canonicalize()
+            .context("canonicalize packaged workspace");
+    }
+
+    std::env::current_dir()
+        .context("resolve current workspace")?
+        .canonicalize()
+        .context("canonicalize workspace")
 }
 
 #[cfg(test)]

--- a/src/runtime_host/subagent_tests.rs
+++ b/src/runtime_host/subagent_tests.rs
@@ -1,5 +1,5 @@
 use chatcmd_mcp::catalog_hash;
-use chatcmd_runtime::OperationContext;
+use chatcmd_runtime::{OperationContext, ShellCreateRequest};
 use serde_json::{Value, json};
 use sqlx::Row as _;
 use tempfile::TempDir;


### PR DESCRIPTION
## Summary

<!-- Explain the problem and the outcome of this change. -->

## Changes

-

## Verification

<!-- List exact commands and manual checks. Say what could not be run and why. -->

```text

```

## Security, privacy, and compatibility

<!-- Cover permissions, tokens, paths, commands, persistence/migrations, MCP/API contracts, public exposure, browser behavior, and breaking changes. Write "None" only after reviewing them. -->

## Screenshots

<!-- Required for visible UI changes. Redact private information. -->

## Checklist

- [ ] The change is focused and targets `dev` unless a maintainer requested otherwise.
- [ ] Tests were added or updated for observable behavior.
- [ ] Rust formatting/Clippy and frontend lint/tests/build were run as applicable.
- [ ] User-facing and protocol documentation was updated.
- [ ] English and Vietnamese UI strings remain aligned.
- [ ] No secret, private data, generated output, database, log, or source map is included.
- [ ] I have the right to submit this contribution under the MIT License.
